### PR TITLE
Improve univariate dev loop docs and DataScaler edge-case tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ pytest copulax/tests/test_copulas_mv.py -v -m "not slow"
 
 # Specific test function
 pytest copulax/tests/test_copulas_mv.py::TestCopulaFitting::test_fit_returns_valid_params -v
+
+# Append output to a running log (bash/zsh)
+pytest copulax/tests/test_univariate.py -v -m "not slow" 2>&1 | tee -a univariate_test_results.txt
 ```
 
 ```powershell

--- a/copulax/_src/univariate/README.md
+++ b/copulax/_src/univariate/README.md
@@ -26,13 +26,19 @@ The base `Univariate` implementation enforces support consistently:
 - fitting uses a penalized objective that discourages parameter proposals
   implying out-of-support observations or non-finite log-density values
 
-### Auto-Discovery
+### Registry Wiring
 
-New distributions are automatically discovered by `copulax/univariate/distributions.py`. To add a distribution:
+New distributions are registered via `copulax/_src/univariate/_registry.py`.
+
+To add a distribution:
 
 1. Create a module in this directory (e.g., `my_dist.py`)
-2. Define a class extending `Univariate` and instantiate a singleton
-3. It will be automatically available via `from copulax.univariate import my_dist`
+2. Define a class extending `Univariate` and export a singleton (e.g., `my_dist`)
+3. Add the class and singleton imports in `_registry.py`
+4. Add the singleton to `_registry` in `_registry.py`
+5. If needed, add the name to `_COMMON_NAMES`
+
+After wiring, it is available from `copulax.univariate`.
 
 ### Fitting Utilities
 

--- a/copulax/tests/test_data_scaler.py
+++ b/copulax/tests/test_data_scaler.py
@@ -314,9 +314,19 @@ def test_pre_fns_non_tuple_raises():
         DataScaler("zscore", pre_fns=jnp.log)
 
 
+def test_pre_fns_wrong_tuple_length_raises():
+    with pytest.raises(ValueError, match="tuple of length 2"):
+        DataScaler("zscore", pre_fns=(jnp.log,))
+
+
 def test_post_fns_non_callable_entry_raises():
     with pytest.raises(TypeError, match="must be callable or None"):
         DataScaler("zscore", post_fns=(jnp.tanh, "not-a-callable"))
+
+
+def test_post_fns_wrong_tuple_length_raises():
+    with pytest.raises(ValueError, match="tuple of length 2"):
+        DataScaler("zscore", post_fns=(jnp.tanh, jnp.arctanh, jnp.tanh))
 
 
 def test_jit_with_pre_fns():

--- a/copulax/tests/test_data_scaler.py
+++ b/copulax/tests/test_data_scaler.py
@@ -309,13 +309,14 @@ def test_post_fns_tanh_arctanh_roundtrip():
     )
 
 
-def test_explicit_noop_fn_pairs_match_default_behavior():
+@pytest.mark.parametrize("method", ["zscore", "minmax"])
+def test_explicit_noop_fn_pairs_match_default_behavior(method):
     rng = np.random.default_rng(141)
     x = _make_data(rng, (120, 2), positive=True)
 
-    default_scaler, default_z = DataScaler("zscore").fit_transform(x)
+    default_scaler, default_z = DataScaler(method).fit_transform(x)
     noop_scaler, noop_z = DataScaler(
-        "zscore",
+        method,
         pre_fns=(None, None),
         post_fns=(None, None),
     ).fit_transform(x)

--- a/copulax/tests/test_data_scaler.py
+++ b/copulax/tests/test_data_scaler.py
@@ -309,6 +309,25 @@ def test_post_fns_tanh_arctanh_roundtrip():
     )
 
 
+def test_explicit_noop_fn_pairs_match_default_behavior():
+    rng = np.random.default_rng(141)
+    x = _make_data(rng, (120, 2), positive=True)
+
+    default_scaler, default_z = DataScaler("zscore").fit_transform(x)
+    noop_scaler, noop_z = DataScaler(
+        "zscore",
+        pre_fns=(None, None),
+        post_fns=(None, None),
+    ).fit_transform(x)
+
+    np.testing.assert_allclose(np.asarray(noop_z), np.asarray(default_z), atol=1e-8)
+    np.testing.assert_allclose(
+        np.asarray(noop_scaler.inverse_transform(noop_z)),
+        np.asarray(default_scaler.inverse_transform(default_z)),
+        atol=1e-8,
+    )
+
+
 @pytest.mark.parametrize(
     "arg_name,arg_value",
     [

--- a/copulax/tests/test_data_scaler.py
+++ b/copulax/tests/test_data_scaler.py
@@ -309,19 +309,16 @@ def test_post_fns_tanh_arctanh_roundtrip():
     )
 
 
-def test_pre_fns_non_tuple_raises():
-    with pytest.raises(ValueError, match="pre_fns must be a"):
-        DataScaler("zscore", pre_fns=jnp.log)
-
-
-def test_post_fns_non_tuple_raises():
-    with pytest.raises(ValueError, match="post_fns must be a"):
-        DataScaler("zscore", post_fns=jnp.tanh)
-
-
-def test_pre_fns_wrong_tuple_length_raises():
-    with pytest.raises(ValueError, match="tuple of length 2"):
-        DataScaler("zscore", pre_fns=(jnp.log,))
+@pytest.mark.parametrize(
+    "arg_name,arg_value",
+    [
+        ("pre_fns", jnp.log),
+        ("post_fns", jnp.tanh),
+    ],
+)
+def test_fn_pairs_non_tuple_raises(arg_name, arg_value):
+    with pytest.raises(ValueError, match=f"{arg_name} must be a"):
+        DataScaler("zscore", **{arg_name: arg_value})
 
 
 def test_post_fns_non_callable_entry_raises():
@@ -329,9 +326,16 @@ def test_post_fns_non_callable_entry_raises():
         DataScaler("zscore", post_fns=(jnp.tanh, "not-a-callable"))
 
 
-def test_post_fns_wrong_tuple_length_raises():
+@pytest.mark.parametrize(
+    "arg_name,arg_value",
+    [
+        ("pre_fns", (jnp.log,)),
+        ("post_fns", (jnp.tanh, jnp.arctanh, jnp.tanh)),
+    ],
+)
+def test_fn_pairs_wrong_tuple_length_raises(arg_name, arg_value):
     with pytest.raises(ValueError, match="tuple of length 2"):
-        DataScaler("zscore", post_fns=(jnp.tanh, jnp.arctanh, jnp.tanh))
+        DataScaler("zscore", **{arg_name: arg_value})
 
 
 def test_jit_with_pre_fns():

--- a/copulax/tests/test_data_scaler.py
+++ b/copulax/tests/test_data_scaler.py
@@ -314,6 +314,11 @@ def test_pre_fns_non_tuple_raises():
         DataScaler("zscore", pre_fns=jnp.log)
 
 
+def test_post_fns_non_tuple_raises():
+    with pytest.raises(ValueError, match="post_fns must be a"):
+        DataScaler("zscore", post_fns=jnp.tanh)
+
+
 def test_pre_fns_wrong_tuple_length_raises():
     with pytest.raises(ValueError, match="tuple of length 2"):
         DataScaler("zscore", pre_fns=(jnp.log,))

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -191,3 +191,13 @@ and prefer single test functions while iterating.
    # keep an append-only log while iterating
    pytest copulax/tests/test_copulas_mv.py -v -m "not slow" *>&1 `
      | Tee-Object -FilePath copula_test_results.txt -Append
+
+.. code-block:: bash
+
+    # keep an append-only log while iterating (macOS/Linux)
+    pytest copulax/tests/test_univariate.py -v -m "not slow" 2>&1 \
+       | tee -a univariate_test_results.txt
+
+    # narrow to a target distribution during local development
+    pytest copulax/tests/test_univariate.py -v -k "gpd" 2>&1 \
+       | tee -a univariate_test_results.txt


### PR DESCRIPTION
What changed\n- added bash append-only test log commands in README/getting-started for the univariate loop\n- added DataScaler tests for invalid pre_fns/post_fns tuple lengths\n\nWhy now\n- this keeps first-time iteration tighter for contributors on macOS/Linux\n- the extra tests lock a small constructor-validation edge case\n\nLeft for later\n- broader univariate distribution work (implementation-level changes) will stay in separate PRs